### PR TITLE
Fix/Slop-64/RSVP button on fest page

### DIFF
--- a/keystone.ts
+++ b/keystone.ts
@@ -43,5 +43,5 @@ export default withAuth(
     },
     lists: Models,
     session,
-  })
+  }),
 );

--- a/models/fest.ts
+++ b/models/fest.ts
@@ -4,17 +4,11 @@ import { text, calendarDay, relationship } from "@keystone-6/core/fields";
 import type { Lists } from ".keystone/types";
 
 export const Fest: ListConfig<Lists.Fest.TypeInfo<any>, any> = list({
-  // Any active user can create/update/delete fests, but only the owner of a fest (or an admin) can update/delete a given fest
+  // Any active user can create/update fests, but only the owner of a fest (or an admin) can delete a given fest
   access: {
     item: {
       create: ({ session }) => session?.data.status === "active",
-      update: async ({ session, item }) => {
-        // if the owner of this fest is the same as the logged in user OR the logged in user is an admin, allow the operation
-        return (
-          (!!session?.data.id && session.data.id === item.creatorId) ||
-          !!session?.data.isAdmin
-        );
-      },
+      update: ({ session }) => session?.data.status === "active",
       delete: async ({ session, item }) => {
         // if the owner of this fest is the same as the logged in user OR the logged in user is an admin, allow the operation
         return (


### PR DESCRIPTION
## Describe your changes
**Important - This branch is intended to run with this frontend branch:**

https://github.com/jahorwitz/slopopedia/pull/82

With these 2 branches running, we should be able to click the "I'm going" button on the fests page, with no errors occurring.

Previously when invited to a Fest, we were not able to click on the ‘I’m Going’ button to RSVP yes to the fest. Nor could we click it a 2nd time to be removed from going to the Fest. The issue was that updating fests was restricted to the fest owner or an admin. This branch removes that restriction.

These buttons should now work:
![2024-05-09_10-03](https://github.com/jahorwitz/slopopedia-api/assets/112486038/4186de3f-b9d3-4865-b3ff-e0a9277e6958)

## Issue ticket number and link
slop-64
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-64

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to custom resolvers, I have added / updated automated tests
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
